### PR TITLE
✨ feat: credentials-path를 옵션으로 받도록 추가한다

### DIFF
--- a/core/cli/argument-parser.ts
+++ b/core/cli/argument-parser.ts
@@ -19,6 +19,7 @@ class CliArgumentParser implements TContract {
       resultsPath: "",
       help: false,
       version: false,
+      credentialsPath: "playwright/.auth/credentials.json",
     };
 
     let i = 0;
@@ -71,6 +72,14 @@ class CliArgumentParser implements TContract {
           options.version = true;
           break;
 
+        case "--credentials":
+          options.credentialsPath = this.#nextArgument(
+            i,
+            "--credentials 옵션에는 Service Account 키 파일 경로가 필요합니다"
+          );
+          i++;
+          break;
+
         default:
           this.#handleDefaultArgument(arg, options);
           break;
@@ -105,4 +114,5 @@ type TCliOptions = {
   resultsPath: string;
   help: boolean;
   version: boolean;
+  credentialsPath: string;
 };

--- a/core/cli/command-handler.ts
+++ b/core/cli/command-handler.ts
@@ -15,11 +15,15 @@ class CommandHandler implements TContract {
   async generateTestCode(options: TCliOptions): Promise<void> {
     console.log(`🔗 Google Sheets URL: ${options.sheetsUrl}`);
     console.log(`📁 출력 디렉토리: ${options.outputDir}`);
+    console.log(`🔑 Service Account 키: ${options.credentialsPath}`);
 
     try {
       await fs.ensureDir(options.outputDir);
 
-      const collector = createScenarioCollector(options.sheetsUrl);
+      const collector = createScenarioCollector(
+        options.sheetsUrl,
+        options.credentialsPath
+      );
       const scenarios = await collector.collect();
 
       const stubGenerator = new PlaywrightStubGenerator();
@@ -33,13 +37,18 @@ class CommandHandler implements TContract {
   async updateTestResults(options: TCliOptions): Promise<void> {
     console.log(`🔗 Google Sheets URL: ${options.sheetsUrl}`);
     console.log(`📄 결과 JSON: ${options.resultsPath}`);
+    console.log(`🔑 Service Account 키: ${options.credentialsPath}`);
 
     try {
       if (!options.resultsPath) {
         throw new Error("--results 옵션이 필요합니다");
       }
 
-      new TestResultUpdater(options.sheetsUrl, options.resultsPath).update();
+      new TestResultUpdater(
+        options.sheetsUrl,
+        options.resultsPath,
+        options.credentialsPath
+      ).update();
     } catch (error) {
       console.error("\n❌ 결과 업데이트 실패:", error);
       throw error;
@@ -53,30 +62,37 @@ class CommandHandler implements TContract {
 
   showUsage(): void {
     console.log(`
-사용법: e2e-autogen <Google Sheets URL> [옵션]
+사용법: e2e-autogen [옵션] <서브커맨드> [서브커맨드 옵션]
+
+전역 옵션:
+  -h, --help          도움말 표시
+  -v, --version       버전 정보 표시
 
 서브커맨드:
   generate            Google Sheets → Playwright 스텁 생성 (기본값)
   update              Playwright 결과 JSON → Google Sheets 업데이트
 
-공통 옵션:
-  <URL>               Google Sheets URL (필수)
+서브커맨드 공통 옵션:
+  --sheets, --url     Google Sheets URL (필수)
+  --credentials       Service Account 키 파일 경로 (기본값: playwright/.auth/credentials.json)
 
-generate 전용:
+generate 옵션:
   --output, -o <dir>  출력 디렉토리 (기본값: ./__generated__/playwright)
 
-update 전용:
+update 옵션:
   --results, -r <file> Playwright JSON 리포터 파일 경로 (필수)
-  --help, -h           도움말 표시
-  --version, -v        버전 정보 표시
 
 예시:
   # 스텁 코드 생성
   e2e-autogen generate --sheets "https://docs.google.com/..." -o ./playwright/__generated__
 
   # 결과 업데이트
-  e2e-autogen update --sheets "https://docs.google.com/..." \
+  e2e-autogen update --sheets "https://docs.google.com/..." \\
                     --results ./playwright/reporters/results.json
+
+  # 커스텀 Service Account 키 사용
+  e2e-autogen generate --sheets "https://docs.google.com/..." \\
+                      --credentials ./custom/path/credentials.json
 `);
   }
 }

--- a/core/results-updater/index.ts
+++ b/core/results-updater/index.ts
@@ -25,13 +25,14 @@ class TestResultUpdater implements TContract {
   readonly #sheetsService: GoogleSheetsService;
   readonly #columnUtil: ColumnUtil;
 
-  constructor(sheetsUrl: string, resultsPath: string) {
+  constructor(sheetsUrl: string, resultsPath: string, credentialsPath: string) {
     if (!sheetsUrl) throw new Error("sheetsUrl is required");
     if (!resultsPath) throw new Error("resultsPath is required");
+    if (!credentialsPath) throw new Error("credentialsPath is required");
 
     this.#sheetsUrl = sheetsUrl;
     this.#resultsPath = resultsPath;
-    this.#sheetsService = new GoogleSheetsService();
+    this.#sheetsService = new GoogleSheetsService(credentialsPath);
     this.#columnUtil = new ColumnUtil();
   }
 

--- a/core/scenario-sheets/index.ts
+++ b/core/scenario-sheets/index.ts
@@ -3,9 +3,12 @@ import { SpreadsheetUrlParser } from "../sheets/spreadsheet-url-parser";
 import { ScenarioSheetFactory } from "./scenario-sheet-factory";
 import { ScenarioCollector } from "./scenario-collector";
 
-function createScenarioCollector(url: string): ScenarioCollector {
+function createScenarioCollector(
+  url: string,
+  credentialsPath: string
+): ScenarioCollector {
   const parser = new SpreadsheetUrlParser(url);
-  const sheetsService = new GoogleSheetsService();
+  const sheetsService = new GoogleSheetsService(credentialsPath);
   const factory = new ScenarioSheetFactory(sheetsService);
 
   return new ScenarioCollector(url, parser, sheetsService, factory);

--- a/core/sheets/config.ts
+++ b/core/sheets/config.ts
@@ -1,6 +1,3 @@
-import path from "path";
-import process from "process";
-
 /**
  * 컬럼 매핑 설정 (스프레드시트 컬럼 순서)
  */
@@ -21,12 +18,6 @@ export const COLUMN_MAPPING = {
 export const GOOGLE_SHEETS_CONFIG = {
   // 인증 범위
   SCOPES: ["https://www.googleapis.com/auth/spreadsheets"],
-
-  // Service Account 키 파일 경로
-  CREDENTIALS_PATH: path.join(
-    process.cwd(),
-    "playwright/.auth/credentials.json"
-  ),
 
   // 헤더 행 감지를 위한 초기 범위 (두 번째 행까지 헤더 행으로 감지)
   HEADER_DETECTION_RANGE: "1:2",

--- a/core/sheets/google-sheets-service.ts
+++ b/core/sheets/google-sheets-service.ts
@@ -1,4 +1,6 @@
 import { google } from "googleapis";
+import path from "path";
+import process from "process";
 import { GOOGLE_SHEETS_CONFIG } from "./config";
 
 type TContract = {
@@ -22,9 +24,9 @@ class GoogleSheetsService implements TContract {
   #auth: any = null;
   #sheets: any = null;
 
-  constructor() {
-    this.#credentialsPath = GOOGLE_SHEETS_CONFIG.CREDENTIALS_PATH;
-    this.#scopes = GOOGLE_SHEETS_CONFIG.SCOPES;
+  constructor(credentialsPath: string) {
+    this.#credentialsPath = path.join(process.cwd(), credentialsPath);
+    this.#scopes = [...GOOGLE_SHEETS_CONFIG.SCOPES];
   }
 
   /**


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

- 기존에는 playwright/.auth/credentials.json로 하드코딩되어 있어 유연성이 부족
- Service Account 키 파일 경로를 CLI 옵션으로 받을 수 있도록 개선

✔️ Related issues #16 
- Close #16 

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

### 🔑 Key changes
**1. CLI 옵션 추가**
- `--credentials` 옵션 추가 (기본값: `playwright/.auth/credentials.json`)
- 모든 서브커맨드에서 사용 가능한 공통 옵션으로 구현

**2. CLI 도움말 구조 개선**
- 전역 옵션(-h, -v)과 서브커맨드 옵션을 명확히 구분
- URL 관련 옵션을 서브커맨드 공통 옵션으로 이동
- 사용 예시에 커스텀 credentials 경로 사용 예시 추가

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

```bash
# 기본 동작 (기본 경로 사용)
e2e-autogen generate --sheets "https://docs.google.com/..."

# 커스텀 경로 사용
e2e-autogen generate --sheets "https://docs.google.com/..." \
                    --credentials ./custom/path/credentials.json

# 결과 업데이트에서 사용
e2e-autogen update --sheets "https://docs.google.com/..." \
                   --results ./results.json \
                   --credentials ./custom/path/credentials.json
```

## 💬 코멘트 [#](#comments) <span id="comments"></span>

1. 기존 동작과의 호환성
- 기본값이 playwright/.auth/credentials.json로 설정되어 있어 기존 사용자들의 동작에는 영향이 없습니다.
- `--credentials` 옵션은 선택적이므로 하위 호환성이 보장됩니다.


