### PR TITLE
✨ feat: API 순차 응답 및 Path Param 지원을 위한 mockApiResponses 리팩터링

### DIFF
--- a/packages/playwright/fixtures/mock-api-responses-fixture.ts
+++ b/packages/playwright/fixtures/mock-api-responses-fixture.ts
@@ -1,67 +1,126 @@
-import { test as base } from "@playwright/test";
+import { test as base, type Page, type Route } from '@playwright/test';
+
+type TMockRequest = { method: string; url: string };
+type TMockResponse = { status: number; headers?: Record<string, string>; body?: unknown };
+type THttpRestItem = {
+  type: 'http-rest';
+  request: TMockRequest;
+  response: TMockResponse;
+};
 
 type TFixtures = {
   mockApiResponses: (data: unknown) => Promise<void>;
 };
 
 /**
- * api-recorder로 기록한 JSON 데이터를 받아서 API 모킹을 수행하는 fixture입니다.
+ * 입력된 데이터가 유효한 HttpRestItem인지 확인하는 Type Guard
  */
-const mockApiResponsesTest = base.extend<TFixtures>({
+const isValidMockItem = (item: unknown): item is THttpRestItem => {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'type' in item &&
+    typeof item.type === 'string' &&
+    item.type === 'http-rest' &&
+    'request' in item &&
+    typeof item.request === 'object' &&
+    item.request !== null &&
+    'method' in item.request &&
+    typeof item.request.method === 'string' &&
+    'url' in item.request &&
+    typeof item.request.url === 'string' &&
+    'response' in item &&
+    typeof item.response === 'object' &&
+    item.response !== null &&
+    'status' in item.response &&
+    typeof item.response.status === 'number' &&
+    'headers' in item.response &&
+    typeof item.response.headers === 'object' &&
+    'body' in item.response &&
+    typeof item.response.body === 'object'
+  );
+};
+
+/**
+ * {param} 형태의 URL 패턴을 Playwright가 인식할 수 있는 정규식으로 변환합니다.
+ */
+const createUrlRegex = (urlPattern: string): RegExp => {
+  const escapedPattern = urlPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // 특수문자 이스케이프
+  const regexPattern = escapedPattern.replace(/\\{[^}]+\\}/g, '[^/]+'); // {param} -> [^/]+ (슬래시 제외 모든 문자)
+  return new RegExp(`^${regexPattern}$`);
+};
+
+/**
+ * 데이터를 'Method::URL' 키 기준으로 그룹화합니다.
+ */
+const groupResponsesByKey = (data: THttpRestItem[]) => {
+  return data.reduce((acc, item) => {
+    const key = `${item.request.method}::${item.request.url}`;
+    if (!acc.has(key)) {
+      acc.set(key, []);
+    }
+    acc.get(key)?.push(item.response);
+    return acc;
+  }, new Map<string, TMockResponse[]>());
+};
+
+
+/**
+ * 특정 Route에 대한 요청 처리 핸들러를 생성합니다.
+ * Closure를 사용하여 호출 횟수(callCount) 상태를 관리합니다.
+ */
+const createRouteHandler = (responses: TMockResponse[]) => {
+  let callCount = 0;
+
+  return async (route: Route) => {
+    const response = responses[callCount] || responses[responses.length - 1];
+
+    if (callCount < responses.length) callCount++;
+
+    await route.fulfill({
+      status: response.status,
+      headers: response.headers,
+      body: response.body ? JSON.stringify(response.body) : undefined,
+    });
+  };
+};
+
+/**
+ * 페이지에 모킹 라우트를 등록합니다.
+ */
+const registerMockRoutes = async (page: Page, mockData: unknown) => {
+  if (!Array.isArray(mockData)) {
+    throw new Error('Mock data must be an array');
+  }
+
+  const validItems = mockData.filter(isValidMockItem);
+
+  const responseMap = groupResponsesByKey(validItems);
+
+  const routePromises = Array.from(responseMap.entries()).map(async ([key, responses]) => {
+    const [method, urlPattern] = key.split('::');
+    const urlRegex = createUrlRegex(urlPattern);
+    const handler = createRouteHandler(responses);
+
+    await page.route(
+      url => urlRegex.test(url.href),
+      async route => {
+        if (route.request().method() === method) {
+          await handler(route);
+        } else {
+          await route.fallback();
+        }
+      },
+    );
+  });
+
+  await Promise.all(routePromises);
+};
+
+export const mockApiResponsesTest = base.extend<TFixtures>({
   mockApiResponses: async ({ page }, use) => {
     await use(async (data: unknown) => {
-      if (!Array.isArray(data)) {
-        throw new Error("data must be an array");
-      }
-
-      const httpRestData = data.filter(
-        (
-          item
-        ): item is {
-          request: { method: string; url: string };
-          response: {
-            status: number;
-            headers?: Record<string, string>;
-            body: unknown;
-          };
-        } => {
-          return (
-            typeof item === "object" &&
-            item !== null &&
-            "type" in item &&
-            item.type === "http-rest" &&
-            "request" in item &&
-            "response" in item &&
-            typeof item.request === "object" &&
-            item.request !== null &&
-            "method" in item.request &&
-            "url" in item.request &&
-            typeof item.response === "object" &&
-            item.response !== null &&
-            "status" in item.response &&
-            "body" in item.response
-          );
-        }
-      );
-
-      for (const item of httpRestData) {
-        const { method, url } = item.request;
-        const { status, headers, body } = item.response;
-
-        await page.route(url, async (route) => {
-          if (route.request().method() === method) {
-            await route.fulfill({
-              status,
-              headers,
-              body: JSON.stringify(body),
-            });
-          } else {
-            await route.continue();
-          }
-        });
-      }
+      await registerMockRoutes(page, data);
     });
   },
 });
-
-export { mockApiResponsesTest };


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

<!-- 작업하게 된 이유/배경 설명 -->

기존 mockApiResponses 픽스처를 사용하여 API 모킹을 할 때 다음과 같은 두 가지 이슈가 발견되어 리팩터링을 진행했습니다.

### 동일 URL 중복 호출 문제 (Overwrite Issue):
- Playwright의 page.route는 동일한 URL 패턴에 대해 여러 번 핸들러를 등록할 경우, 마지막에 등록된 핸들러가 이전 핸들러를 덮어쓰거나 우선순위를 가집니다.
- 이로 인해 하나의 시나리오에서 **첫 번째 호출은 200 OK, 두 번째 호출은 400 Error**와 같이 상태가 변하는 순차적인 API 응답을 테스트할 수 없었습니다.

### Path Parameter 미지원:
- URL 매칭이 단순 문자열 일치(===)로 구현되어 있어, /users/{userId}와 같이 동적인 Path Parameter가 포함된 API를 모킹할 수 없었습니다.
- 이러한 문제를 해결하여 시나리오 기반의 순차적 모킹과 유연한 URL 매칭을 지원하기 위해 작업을 진행했습니다.

<!-- ⚠️  버그/오류의 경우, 문제를 정의 -->
<!-- 🆕  새로운 스펙의 경우, 스펙 설명 -->

<!-- 관련 이슈 링크 -->

✔️ Related issues #41 

<!-- Merge시 자동으로 close 하고 싶은 이슈가 있다면 -->
<!-- - Resolve # -->
<!-- - Fix # -->
<!-- - Close # -->

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

<!-- 작업 내용 설명 -->

### 🔑 Key changes - 주요 변화
1. 응답 그룹화 및 순차 처리 (Sequential Response)
- 입력받은 모킹 데이터를 Method + URL 기준으로 그룹화(Map)했습니다.
- 단일 Route 핸들러 내부에서 호출 횟수(callCount)를 추적하여, 요청이 들어올 때마다 순서대로 준비된 응답을 반환하도록 변경했습니다.
- 준비된 응답 리스트가 소진되면, 마지막 응답을 계속 반환하여 테스트가 중단되지 않도록 방어 로직을 추가했습니다.

2. Regex 기반의 Path Parameter 지원
- 기존의 단순 문자열 매칭 대신 정규식(Regex) 매칭을 도입했습니다.
- URL 패턴 내의 {param} 형태를 [^/]+ 정규식으로 자동 변환하여, 동적인 ID 값 등이 들어와도 정상적으로 라우팅되도록 개선했습니다.

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

<!-- 이미지, 영상, 시나리오 첨부 -->

### 변경 전 (AS-IS)
동일 API가 여러 번 정의되어 있어도, Playwright 특성상 마지막 정의만 적용됨.

```json
// mock data
[
  { "url": "/api/test", "response": { "status": 200 } },
  { "url": "/api/test", "response": { "status": 500 } }
]

// 결과: 항상 500 에러만 반환되거나 동작 예측 불가
```

### 변경 후 (TO-BE)
순차적으로 응답을 꺼내서 반환함.

```ts
// Test Code Scenario
await page.getByRole('button', { name: '조회' }).click(); // 첫 번째 클릭 -> 200 OK
await expect(page.getByText('성공')).toBeVisible();

await page.getByRole('button', { name: '조회' }).click(); // 두 번째 클릭 -> 500 Error
await expect(page.getByText('에러 발생')).toBeVisible();
```

## 💬 코멘트 [#](#comments) <span id="comments"></span>

<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항 등-->
